### PR TITLE
Fix janky way to get caption from request

### DIFF
--- a/app/api/image_routes.py
+++ b/app/api/image_routes.py
@@ -155,8 +155,7 @@ def edit_caption(id):
     Route to edit caption for specfied image.
     '''
     update_image = Image.query.filter(id == Image.id).first()
-    # Temporary solution -- * WILL COMEBACK AND REFACTOR *
-    update_image.caption = request.data.decode('UTF-8')[1:-1]
+    update_image.caption = request.json
 
     db.session.commit()
 


### PR DESCRIPTION
This PR fixes the janky way we parsed the caption from the request, for the edit caption API endpoint. 